### PR TITLE
Replace kratix examples in usage docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 We use dates instead of semantic versions.
 
+## 2026-06-25
+
+### Changed
+
+- Replaced kratix-based examples in `README.md` and `add-new-image.sh` usage with neutral examples, as kratix is being removed (giantswarm/giantswarm#36422).
+
 ## 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We want a custom image for `nginx`:
 You can use the `add-new-image.sh` script to generate new modules. For example:
 
 ```shell
-./add-new-image.sh -o "@giantswarm/team-honeybadger" -i "kratix" -f "yq" -b "gsoci.azurecr.io/giantswarm/kratix-base-cli:0.1.0"
+./add-new-image.sh -o "@giantswarm/team-honeybadger" -i "alpine" -f "yq" -b "quay.io/alpine:3.16.2"
 ```
 
 # How to work with this repository?

--- a/add-new-image.sh
+++ b/add-new-image.sh
@@ -23,8 +23,8 @@ function usage() {
   echo ""
   echo "Example usage:"
   echo ""
-  echo "  $0 -o \"@giantswarm/team-honeybadger\" -i \"kratix\" -b \"gsoci.azurecr.io/giantswarm/kratix-base-cli:0.1.0\""
-  echo "  $0 -o \"@giantswarm/team-honeybadger\" -i \"alpine\" -f \"kubectl\" -b \"gsoci.azurecr.io/giantswarm/kratix-base-cli:0.1.0\""
+  echo "  $0 -o \"@giantswarm/team-honeybadger\" -i \"yq\" -b \"quay.io/alpine:3.16.2\""
+  echo "  $0 -o \"@giantswarm/team-honeybadger\" -i \"alpine\" -f \"kubectl\" -b \"quay.io/alpine:3.16.2\""
 }
 
 # arguments


### PR DESCRIPTION
Kratix is being removed as an unused IDP experiment (refs giantswarm/giantswarm#36422); its `kratix-base-cli` base image will no longer exist. This replaces the kratix-based examples in `README.md` and the `add-new-image.sh` usage output with neutral, still-valid examples so the docs keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)