### PR TITLE
add more packages to claude-code-ci image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use dates instead of semantic versions.
 
 - Upgraded Python dependencies in `docs-scriptrunner` image
 - Upgraded `docs-scriptrunner` base image from Python 3.12.0-alpine3.18 to 3.14-alpine3.23
+- Added `py3-yaml` and `kubectl` packages to `claude-code-ci` image.
 
 ## 2026-02-07
 

--- a/claude-code-ci/default.dockerfile
+++ b/claude-code-ci/default.dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache \
     wget \
     python3 \
     py3-pip \
+    py3-yaml \
+    kubectl \
     build-base \
     jq \
     ripgrep \


### PR DESCRIPTION
Towards https://github.com/giantswarm/tekton-resources/pull/913

I need those packages to have claude-code succeeding in using the `perf-report` skill from the envoy-gateway-app repo.